### PR TITLE
Add aspectRatio option for images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .phpunit.result.cache
 composer.lock
 .env
+.idea

--- a/src/Embed/Images.php
+++ b/src/Embed/Images.php
@@ -35,8 +35,9 @@ final class Images extends AbstractImages implements Arrayable
      * ```
      *
      * @param  BlobRef|array|callable  $blob
+     * @param ?array{width: int|string, height: int|string} $aspectRatio
      */
-    public function add(string $alt, BlobRef|array|callable $blob): self
+    public function add(string $alt, BlobRef|array|callable $blob, ?array $aspectRatio = null): self
     {
         if (is_callable($blob)) {
             $blob = call_user_func($blob);
@@ -46,10 +47,16 @@ final class Images extends AbstractImages implements Arrayable
             $blob = $blob->toArray();
         }
 
-        $this->images[] = [
+        $imgData = [
             'image' => $blob,
             'alt' => $alt,
         ];
+
+        if ($aspectRatio) {
+            $imgData['aspectRatio'] = $aspectRatio;
+        }
+
+        $this->images[] = $imgData;
 
         return $this;
     }


### PR DESCRIPTION
Images now support aspect ratio like videos for better rendering, 
images without aspect ratio value are displayed as clipped square.

https://docs.bsky.app/docs/advanced-guides/posts#images-embeds